### PR TITLE
Improve/issue 45

### DIFF
--- a/PatrolRewardService/PatrolRewardService.Tests/MutationTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/MutationTest.cs
@@ -12,12 +12,16 @@ namespace PatrolRewardService.Tests;
 public class MutationTest
 {
     private readonly string _conn;
+    private readonly GraphqlClientOptions _configOptions;
 
     public MutationTest()
     {
         var host = Environment.GetEnvironmentVariable("TEST_DB_HOST") ?? "localhost";
         var userName = Environment.GetEnvironmentVariable("TEST_DB_USER") ?? "postgres";
         var pw = Environment.GetEnvironmentVariable("TEST_DB_PW");
+        var graphqlHost = Environment.GetEnvironmentVariable("TEST_GRAPHQL_HOST")!;
+        var jwtSecret = Environment.GetEnvironmentVariable("TEST_JWT_SECRET")!;
+        _configOptions = new GraphqlClientOptions {Host = graphqlHost, Port = 80, JwtIssuer = "issuer", JwtSecret = jwtSecret};
         var connectionString = $"Host={host};Username={userName};Database={GetType().Name};";
         if (!string.IsNullOrEmpty(pw))
         {
@@ -38,8 +42,7 @@ public class MutationTest
         await context.Database.EnsureCreatedAsync();
         var serializedAvatarAddress = avatarAddress.ToString();
         var serializedAgentAddress = agentAddress.ToString();
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
-        var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
+        var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(_configOptions), new LoggerFactory());
         await Assert.ThrowsAsync<GraphQLException>(() => Mutation.PutAvatar(contextService, client, serializedAvatarAddress, serializedAgentAddress));
         Assert.Empty(context.Avatars);
         await context.Database.EnsureDeletedAsync();
@@ -76,8 +79,7 @@ public class MutationTest
         }
         var serializedAvatarAddress = avatarAddress.ToString();
         var serializedAgentAddress = agentAddress.ToString();
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
-        var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
+        var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(_configOptions), new LoggerFactory());
         await contextService.PutClaimPolicy(new List<RewardBaseModel>(), true, TimeSpan.FromHours(12), true, 1,
             "password", DateTime.UtcNow, DateTime.MaxValue);
         var result = await Mutation.PutAvatar(contextService, client, serializedAvatarAddress, serializedAgentAddress);
@@ -133,8 +135,7 @@ public class MutationTest
         await context.RewardPolicies.AddAsync(policy);
         await context.Avatars.AddAsync(avatar);
         // await context.SaveChangesAsync();
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
-        var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
+        var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(_configOptions), new LoggerFactory());
         var privateKey = new PrivateKey();
         var signerOptions = new SignerOptions
         {

--- a/PatrolRewardService/PatrolRewardService.Tests/MutationTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/MutationTest.cs
@@ -142,7 +142,7 @@ public class MutationTest
             GenesisHash = "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce"
         };
         var signer = new Signer(new OptionsWrapper<SignerOptions>(signerOptions));
-        var txId = await Mutation.ClaimTx(contextService, signer, avatarAddress.ToString(), avatar, policy, new NineChroniclesClient.Avatar());
+        var txId = await Mutation.ClaimTx(contextService, signer, avatarAddress.ToString(), avatar, policy, new NineChroniclesClient.Avatar(), client);
         Assert.Equal(1, avatar.ClaimCount);
         Assert.Equal(1, context.Transactions.Count(t => t.ClaimCount == 0));
         await Mutation.RetryTransaction(contextService, signer, client, txId, "password");

--- a/PatrolRewardService/PatrolRewardService.Tests/MutationTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/MutationTest.cs
@@ -38,7 +38,7 @@ public class MutationTest
         await context.Database.EnsureCreatedAsync();
         var serializedAvatarAddress = avatarAddress.ToString();
         var serializedAgentAddress = agentAddress.ToString();
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-internal-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
+        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
         var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
         await Assert.ThrowsAsync<GraphQLException>(() => Mutation.PutAvatar(contextService, client, serializedAvatarAddress, serializedAgentAddress));
         Assert.Empty(context.Avatars);
@@ -76,7 +76,7 @@ public class MutationTest
         }
         var serializedAvatarAddress = avatarAddress.ToString();
         var serializedAgentAddress = agentAddress.ToString();
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-internal-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
+        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
         var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
         await contextService.PutClaimPolicy(new List<RewardBaseModel>(), true, TimeSpan.FromHours(12), true, 1,
             "password", DateTime.UtcNow, DateTime.MaxValue);
@@ -133,7 +133,7 @@ public class MutationTest
         await context.RewardPolicies.AddAsync(policy);
         await context.Avatars.AddAsync(avatar);
         // await context.SaveChangesAsync();
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-internal-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
+        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
         var client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
         var privateKey = new PrivateKey();
         var signerOptions = new SignerOptions

--- a/PatrolRewardService/PatrolRewardService.Tests/MutationTypeTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/MutationTypeTest.cs
@@ -35,7 +35,7 @@ public class MutationTypeTest
         var myConfiguration = new Dictionary<string, string>
         {
             {"ConnectionStrings:PatrolReward", connectionString},
-            {"GraphqlClientConfig:Host", "http://heimdall-internal-validator-1.nine-chronicles.com"},
+            {"GraphqlClientConfig:Host", "http://heimdall-validator-1.nine-chronicles.com"},
             {"GraphqlClientConfig:Port", "80"},
             {"SignerConfig:PrivateKey", ByteUtil.Hex(privateKey.ByteArray)},
             {"SignerConfig:GenesisHash", ByteUtil.Hex(blockHash.ByteArray)},

--- a/PatrolRewardService/PatrolRewardService.Tests/NineChroniclesClientTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/NineChroniclesClientTest.cs
@@ -15,7 +15,7 @@ public class NineChroniclesClientTest
 
     public NineChroniclesClientTest()
     {
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-internal-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
+        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
         _client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
     }
 

--- a/PatrolRewardService/PatrolRewardService.Tests/NineChroniclesClientTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/NineChroniclesClientTest.cs
@@ -15,7 +15,9 @@ public class NineChroniclesClientTest
 
     public NineChroniclesClientTest()
     {
-        var configOptions = new GraphqlClientOptions {Host = "http://heimdall-validator-1.nine-chronicles.com", Port = 80, JwtIssuer = "issuer", JwtSecret = "onsolhjcqbrawkvznmhuukoqunyzyigmwfixgqwvnlqlbpvqfvhfcyslwmqerpyihowcyiksouulydbuuuvlgpfskhzrcrsjorqkwnfxkkosvkkdwcxhjitwyxbfezig"};
+        var graphqlHost = Environment.GetEnvironmentVariable("TEST_GRAPHQL_HOST")!;
+        var jwtSecret = Environment.GetEnvironmentVariable("TEST_JWT_SECRET")!;
+        var configOptions = new GraphqlClientOptions {Host = graphqlHost, Port = 80, JwtIssuer = "issuer", JwtSecret = jwtSecret};
         _client = new NineChroniclesClient(new OptionsWrapper<GraphqlClientOptions>(configOptions), new LoggerFactory());
     }
 

--- a/PatrolRewardService/PatrolRewardService.Tests/NineChroniclesClientTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/NineChroniclesClientTest.cs
@@ -49,4 +49,11 @@ public class NineChroniclesClientTest
         Assert.NotNull(msg.Headers.Authorization);
         Assert.Equal(request.Authentication, msg.Headers.Authorization);
     }
+
+    [Fact]
+    public async Task Nonce()
+    {
+        var nonce = await _client.Nonce();
+        Assert.True(nonce > 0L);
+    }
 }

--- a/PatrolRewardService/PatrolRewardService.Tests/QueryTypeTest.cs
+++ b/PatrolRewardService/PatrolRewardService.Tests/QueryTypeTest.cs
@@ -36,7 +36,7 @@ public class QueryTypeTest
         var myConfiguration = new Dictionary<string, string>
         {
             {"ConnectionStrings:PatrolReward", connectionString},
-            {"GraphqlClientConfig:Host", "http://heimdall-internal-validator-1.nine-chronicles.com"},
+            {"GraphqlClientConfig:Host", "http://heimdall-validator-1.nine-chronicles.com"},
             {"GraphqlClientConfig:Port", "80"},
             {"SignerConfig:PrivateKey", ByteUtil.Hex(privateKey.ByteArray)},
             {"SignerConfig:GenesisHash", ByteUtil.Hex(blockHash.ByteArray)},

--- a/PatrolRewardService/PatrolRewardService/GraphqlTypes/NineChroniclesClient.cs
+++ b/PatrolRewardService/PatrolRewardService/GraphqlTypes/NineChroniclesClient.cs
@@ -232,6 +232,39 @@ query($txIds: [TxId]!) {
         throw new GraphQLException(msg);
     }
 
+    /// <summary>
+    /// Get patrol reward address next nonce from node
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="GraphQLException"></exception>
+    public async Task<long> Nonce()
+    {
+        var query = @"query {
+  nextTxNonce(address: ""0xCaD60f18b4Ba189f7f1c14E2267D9b20F5b16Ff5"")
+}";
+        var request = new GraphQLHttpRequestWithAuth
+        {
+            Query = query,
+            Authentication = new AuthenticationHeaderValue("Bearer",Token()),
+        };
+
+        GraphQLResponse<NonceResponse> resp;
+        try
+        {
+            resp = await _client.SendQueryAsync<NonceResponse>(request);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("{Msg}", e.Message);
+            throw;
+        }
+
+        if (resp.Errors is null) return resp.Data.NextTxNonce;
+
+        var msg = resp.Errors.Aggregate("", (current, error) => current + error.Message + "\n");
+        throw new GraphQLException(msg);
+    }
+
     public class GetAvatarResult
     {
         public StateQuery StateQuery;
@@ -303,6 +336,11 @@ query($txIds: [TxId]!) {
     public class TipResult
     {
         public int Index;
+    }
+
+    public class NonceResponse
+    {
+        public long NextTxNonce;
     }
 
     public class GraphQLHttpRequestWithAuth : GraphQLHttpRequest {

--- a/PatrolRewardService/PatrolRewardService/Mutation.cs
+++ b/PatrolRewardService/PatrolRewardService/Mutation.cs
@@ -80,14 +80,15 @@ public class Mutation
         var policy = contextService.GetPolicy(free, avatarState.Level);
 
         // prepare claim.
-        var txId = await ClaimTx(contextService, signer, avatarAddress, avatar, policy, avatarState);
+        var txId = await ClaimTx(contextService, signer, avatarAddress, avatar, policy, avatarState, client);
         return txId.ToHex();
     }
 
     public static async Task<TxId> ClaimTx(ContextService contextService, Signer signer, string avatarAddress,
-        AvatarModel avatar, RewardPolicyModel policy, NineChroniclesClient.Avatar avatarState)
+        AvatarModel avatar, RewardPolicyModel policy, NineChroniclesClient.Avatar avatarState,
+        NineChroniclesClient client)
     {
-        // check claim interval 
+        // check claim interval
         var lastClaimedAt = avatar.LastClaimedAt ?? avatar.CreatedAt;
         var now = DateTime.UtcNow;
         var diff = now - lastClaimedAt;
@@ -125,7 +126,7 @@ public class Mutation
         // prepare action plain value.
         var memo = $"patrol reward {avatarAddress} / {avatar.ClaimCount}";
         var action = claim.ToClaimItems(avatarState.Address, avatarState.AgentAddress, memo);
-        long nonce = await contextService.GetNonce();
+        long nonce = await contextService.GetNonce(client);
         var tx = signer.Sign(nonce, new[] {action}, 1 * Currencies.Mead, 4L, now + TimeSpan.FromDays(1));
         transaction.TxId = tx.Id;
         transaction.Payload = Convert.ToBase64String(tx.Serialize());


### PR DESCRIPTION
- 테스트 환경에서의 db 초기화 등의 케이스를 고려해 `Transactions` 테이블에서 다음 논스값을 못구해올 경우 서비스가 의존하는 노드에게 논스값을 얻어오도록 처리합니다.

---
- resolve #45 